### PR TITLE
don't get contacts from assignable_users vocabulary.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.5.1 (unreleased)
 ------------------
 
+- Don't get Contacts from assignable_users vocabulary.
+  [tschanzt]
+
 - Fix bug causing duplicate ids in ticketbox configurations (states, releases, etc).
   Duplicate ids occured when an item with a already used title was added.
   [jone]

--- a/izug/ticketbox/content/ticketbox.py
+++ b/izug/ticketbox/content/ticketbox.py
@@ -279,13 +279,16 @@ class TicketBox(folder.ATBTreeFolder):
         users.
         """
         factory = queryUtility(IVocabularyFactory, name='assignable_users')
+
         if factory is None:
             factory = getUtility(IVocabularyFactory,
                                  name='plone.principalsource.Users',
                                  context=self)
-
+            terms = factory(self)
+        else:
+            terms = factory(self, membersonly=True)
         values = []
-        for term in factory(self):
+        for term in terms:
             values.append((term.token, term.title))
         return values
 


### PR DESCRIPTION
@maethu can you take a look at this? After this change, the assignable_users vocabulary only returns members.
