### PR TITLE
Make ticket reference browser startup directory configurable with an adapter

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,12 @@ Changelog
 4.5.4 (unreleased)
 ------------------
 
+- Make ticket reference browser startup directory configurable
+  with an adapter.
+  Add a conditional adapter for workspace integration which resets
+  the startup directory to the workspace.
+  [jone]
+
 - Add permissionmapping for ftw.lawgiver
   [elioschmutz]
 

--- a/izug/ticketbox/browser/response.py
+++ b/izug/ticketbox/browser/response.py
@@ -112,7 +112,8 @@ class Base(BrowserView):
     def mock_reference_field(self):
         """Mocks reference field for response"""
 
-        startuppath = '/'.join(self.context.getPhysicalPath())
+        field = self.context.getField('ticketReferences')
+        startuppath = field.widget.getStartupDirectory(self.context, field)
 
         class Dummy(object):
             # Disable zope security

--- a/izug/ticketbox/configure.zcml
+++ b/izug/ticketbox/configure.zcml
@@ -116,4 +116,10 @@
                 handler=".handlers.move_document_to_reference" />
 
 
+    <adapter factory=".references.DefaultTicketReferenceStartupDirectory" />
+    <configure zcml:condition="installed ftw.workspace">
+        <adapter factory=".workspace.WorkspaceStartupDirectory" />
+    </configure>
+
+
 </configure>

--- a/izug/ticketbox/content/ticket.py
+++ b/izug/ticketbox/content/ticket.py
@@ -5,6 +5,7 @@ from DateTime import DateTime
 from izug.ticketbox import ticketboxMessageFactory as _
 from izug.ticketbox.config import PROJECTNAME
 from izug.ticketbox.interfaces import ITicket
+from izug.ticketbox.interfaces import ITicketReferenceStartupDirectory
 from Products.Archetypes.atapi import AttributeStorage
 from Products.Archetypes.atapi import DateTimeField, CalendarWidget
 from Products.Archetypes.atapi import FileField, FileWidget
@@ -20,6 +21,7 @@ from Products.ATReferenceBrowserWidget.ATReferenceBrowserWidget \
 from zope.interface import implements
 from zope.schema.interfaces import IVocabularyFactory
 from zope.component import getUtility
+from zope.component import getMultiAdapter
 from Products.Archetypes import atapi
 from Products.CMFCore.permissions import ManagePortal
 
@@ -170,7 +172,8 @@ TicketSchema = schemata.ATContentTypeSchema.copy() + Schema((
                 label=_(u'label_references', default=u"References"),
                 allow_browse=True,
                 show_results_without_query=False,
-                restrict_browsing_to_startup_directory=False)),
+                restrict_browsing_to_startup_directory=False,
+                startup_directory_method='getReferenceStartupDirectory')),
 
         ))
 
@@ -259,5 +262,11 @@ class Ticket(base.ATCTFolder):
             obj = aq_parent(aq_parent(parent))
 
         return len([term for term in factory(obj) if term.value])
+
+    security.declarePrivate('getReferenceStartupDirectory')
+    def getReferenceStartupDirectory(self):
+        getter = getMultiAdapter((self, self.REQUEST),
+                                 ITicketReferenceStartupDirectory)
+        return getter.get()
 
 registerType(Ticket, PROJECTNAME)

--- a/izug/ticketbox/interfaces.py
+++ b/izug/ticketbox/interfaces.py
@@ -100,3 +100,17 @@ class IResponseAdder(IViewletManager):
         """
 
 directlyProvides(IResponseAdder, ITALNamespaceData)
+
+
+class ITicketReferenceStartupDirectory(Interface):
+    """Adapter for getting the startup directory for references in the
+    current ticket.
+    """
+
+    def __init__(ticket, request):
+        """Adapts the ticket and the request.
+        """
+
+    def get():
+        """Returns the startup directory path.
+        """

--- a/izug/ticketbox/references.py
+++ b/izug/ticketbox/references.py
@@ -1,0 +1,19 @@
+from izug.ticketbox.interfaces import ITicket
+from izug.ticketbox.interfaces import ITicketReferenceStartupDirectory
+from zope.component import adapts
+from zope.interface import Interface
+from zope.interface import implements
+
+
+class DefaultTicketReferenceStartupDirectory(object):
+    implements(ITicketReferenceStartupDirectory)
+    adapts(ITicket, Interface)
+
+    def __init__(self, ticket, request):
+        self.ticket = ticket
+        self.request = request
+
+    def get(self):
+        url_tool = self.ticket.restrictedTraverse('@@plone_tools').url()
+        path = '/'.join(url_tool.getRelativeContentPath(self.ticket))
+        return path

--- a/izug/ticketbox/testing.py
+++ b/izug/ticketbox/testing.py
@@ -1,3 +1,6 @@
+from ftw.builder.testing import BUILDER_LAYER
+from ftw.builder.testing import functional_session_factory
+from ftw.builder.testing import set_builder_session_factory
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import PLONE_FIXTURE
@@ -5,11 +8,12 @@ from plone.app.testing import PloneSandboxLayer
 from plone.app.testing import applyProfile
 from plone.testing import z2
 from zope.configuration import xmlconfig
+import izug.ticketbox.tests.builder
 
 
 class TicketBoxLayer(PloneSandboxLayer):
 
-    defaultBases = (PLONE_FIXTURE, )
+    defaultBases = (PLONE_FIXTURE, BUILDER_LAYER)
 
     def setUpZope(self, app, configurationContext):
         import Products.DataGridField
@@ -52,5 +56,8 @@ class TicketBoxLayer(PloneSandboxLayer):
 TICKETBOX_FIXTURE = TicketBoxLayer()
 TICKETBOX_INTEGRATION_TESTING = IntegrationTesting(
     bases=(TICKETBOX_FIXTURE, ), name="TicketBox:Integration")
+
 TICKETBOX_FUNCTIONAL_TESTING = FunctionalTesting(
-    bases=(TICKETBOX_FIXTURE, ), name="TicketBox:Functional")
+    bases=(TICKETBOX_FIXTURE,
+           set_builder_session_factory(functional_session_factory)),
+    name="TicketBox:Functional")

--- a/izug/ticketbox/tests/builder.py
+++ b/izug/ticketbox/tests/builder.py
@@ -1,0 +1,14 @@
+from ftw.builder.archetypes import ArchetypesBuilder
+from ftw.builder import builder_registry
+
+
+class TicketBoxBuilder(ArchetypesBuilder):
+    portal_type = 'Ticket Box'
+
+builder_registry.register('ticket box', TicketBoxBuilder)
+
+
+class TicketBuilder(ArchetypesBuilder):
+    portal_type = 'Ticket'
+
+builder_registry.register('ticket', TicketBuilder)

--- a/izug/ticketbox/tests/test_ticket_reference.py
+++ b/izug/ticketbox/tests/test_ticket_reference.py
@@ -1,0 +1,30 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from izug.ticketbox.testing import TICKETBOX_INTEGRATION_TESTING
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
+from plone.app.testing import login
+from plone.app.testing import setRoles
+from unittest2 import TestCase
+
+
+
+class TestReferenceStartupDirectory(TestCase):
+
+    layer = TICKETBOX_INTEGRATION_TESTING
+
+    def setUp(self):
+        portal = self.layer['portal']
+        setRoles(portal, TEST_USER_ID, ['Manager'])
+        login(portal, TEST_USER_NAME)
+
+    def test_startup_directory_is_current_context(self):
+        ticketbox = create(Builder('ticket box')
+                           .titled('THe Ticket Box'))
+
+        ticket = create(Builder('ticket')
+                        .titled('The Ticket')
+                        .within(ticketbox))
+
+        self.assertEquals('the-ticket-box/the-ticket',
+                          ticket.getReferenceStartupDirectory())

--- a/izug/ticketbox/workspace.py
+++ b/izug/ticketbox/workspace.py
@@ -1,0 +1,30 @@
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
+from ftw.workspace.interfaces import IWorkspace
+from ftw.workspace.interfaces import IWorkspaceLayer
+from izug.ticketbox.interfaces import ITicket
+from izug.ticketbox.interfaces import ITicketReferenceStartupDirectory
+from zope.component import adapts
+from zope.interface import implements
+
+
+class WorkspaceStartupDirectory(object):
+    implements(ITicketReferenceStartupDirectory)
+    adapts(ITicket, IWorkspaceLayer)
+
+    def __init__(self, ticket, request):
+        self.ticket = ticket
+        self.request = request
+
+    def get(self):
+        url_tool = self.ticket.restrictedTraverse('@@plone_tools').url()
+        startup_obj = self.get_workspace() or self.ticket
+        return '/'.join(url_tool.getRelativeContentPath(startup_obj))
+
+    def get_workspace(self):
+        context = self.ticket
+        while context and not IPloneSiteRoot.providedBy(context):
+            if IWorkspace.providedBy(context):
+                return context
+            context = aq_parent(aq_inner(context))

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ tests_require = [
     'unittest2',
     'ftw.testing',
     'plone.app.testing',
+    'ftw.builder',
     'collective.MockMailHost',
     ]
 
@@ -79,7 +80,8 @@ setup(name='izug.ticketbox',
         ],
 
       tests_require=tests_require,
-      extras_require=dict(tests=tests_require),
+      extras_require=dict(tests=tests_require,
+                          workspace=['ftw.workspace']),
 
       test_suite='izug.ticketbox.tests.test_docs.test_suite',
       entry_points="""


### PR DESCRIPTION
Add a conditional adapter for workspace integration which resets the startup directory to the workspace.

@maethu 
