### PR TITLE
Style "Add answer" link as button using default styling.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.5.6 (unreleased)
 ------------------
 
+- Style "Add answer" link as button using default styling.
+  [jone]
+
 - Plone 4.3 support.
   [jone]
 

--- a/izug/ticketbox/browser/response.pt
+++ b/izug/ticketbox/browser/response.pt
@@ -105,12 +105,11 @@
     <!-- *************************************************** -->
     <!-- Add Response - with collabsible function -->
     <tal:add condition="python:user.has_permission('izug.ticketbox: Add Ticket', here)">
-        <dl id='addResponse' class='collapsible collapsedOnLoad' style='margin-bottom:10px;'>
+        <dl id="addResponse" class="collapsible collapsedOnLoad" onselectstart="return false;">
             <dt class='collapsibleHeader'>
-                <div i18n:translate="title_add_response" class='add_response'>Add response</div>
+                <div i18n:translate="title_add_response" class="add_response button">Add response</div>
             </dt>
 
-            <!-- <h3 i18n:translate="title_add_response">Add response</h3> -->
             <dd class="collapsibleContent">
                 <div>
                     <form method="post"

--- a/izug/ticketbox/browser/stylesheets/ticketbox.css
+++ b/izug/ticketbox/browser/stylesheets/ticketbox.css
@@ -26,17 +26,16 @@ table.ticketbox-overview td{
     vertical-align: top;
 }
 
-dl.collapsible dt.collapsibleHeader div.add_response {
-    background-color: #00538C;
-    border: 1px solid #666666;
-    color: #FFFFFF;
-    font-size: 1.1em;
-    font-style: inherit;
-    font-weight:bold;
-    height: 100%;
-    line-height: 1em;
-    padding: 0.4em 0.5em;
-    width: 115px;
+#addResponse {
+  margin-top: 2em;
+  margin-bottom: 1em;
+}
+
+#addResponse > .collapsibleHeader {
+  font-size: 100%;
+  padding-left: 0;
+  background: none;
+  margin-top: -0.5em;
 }
 
 body.template-atct_edit #datagridwidget-table-availableStates tr th:first-child,


### PR DESCRIPTION
- Remove custom styling of the "Add answer" link
- Add "button" class to have the default button styling
- Remove [+] and [-] - it looks better without here
- Fix heights / margins of the button and the collapsible
- Prohibit selecting the button text by clicking / double clicking.
## **Before**
## ![screen shot 2013-08-30 at 11 53 18 am](https://f.cloud.github.com/assets/437933/1056582/0e242a3a-115a-11e3-8fd1-578acb5209c6.png)
## **After**
## ![bildschirmfoto 2013-08-30 um 13 37 42](https://f.cloud.github.com/assets/7469/1057068/a68268ec-1168-11e3-8bc9-dc3c1aba5703.png)
## ![bildschirmfoto 2013-08-30 um 13 37 18](https://f.cloud.github.com/assets/7469/1057069/a6849e46-1168-11e3-9c20-ab285a55601e.png)

@ninfaj What do you think about these changes?
I don't like the old styling - but these changes might impact existing installations with other themes.
But I think it is a good default. I also kept the old class `add_response` so that it can be customized in other themes where we don't like to have a default button.
