### PR TITLE
Use unrestrictedTraverse in _get_cached_options_for.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.5.8 (unreleased)
 ------------------
 
+- Use unrestrictedTraverse in _get_cached_options_for, since some parents couldn't
+  be accessible for the logged-in user.
+
 - Add French and English translations.
   [jone]
 

--- a/izug/ticketbox/browser/tabbed/base.py
+++ b/izug/ticketbox/browser/tabbed/base.py
@@ -92,7 +92,7 @@ class BaseTicketListingTab(CatalogListingView):
         if getter_name not in box_cache:
             box_cache[getter_name] = {}
 
-            box = self.context.restrictedTraverse(box_path)
+            box = self.context.unrestrictedTraverse(box_path)
             for option in getattr(box, getter_name)():
                 box_cache[getter_name][option['id']] = option['title']
 


### PR DESCRIPTION
This PR solve the following issue:
Load tabs on a ticketbox also if the logged-in user has no view permission on one or more parents.
