### PR TITLE
Hide the ticket description in the live search results.

### DIFF
--- a/izug/ticketbox/browser/stylesheets/ticketbox.css
+++ b/izug/ticketbox/browser/stylesheets/ticketbox.css
@@ -57,3 +57,7 @@ body.template-atct_edit #datagridwidget-table-availableVarieties tr td:first-chi
 body.template-ticket_view.portaltype-ticket #plone-contentmenu-factories{
     display:none;
 }
+
+.LSDescr {
+    display: none;
+}


### PR DESCRIPTION
This workaround hides the ticket description in the live search results because the description contains HTML tags which are also displayed in the search results. 

Fixes #23.
