### PR TITLE
Re-enable action button.

### DIFF
--- a/izug/ticketbox/browser/stylesheets/ticketbox.css
+++ b/izug/ticketbox/browser/stylesheets/ticketbox.css
@@ -67,11 +67,6 @@ body.template-ticket_view.portaltype-ticket #plone-contentmenu-factories{
     display: none;
 }
 
-
-#plone-contentmenu-actions.deactivated {
-    display: none;
-}
-
 #searchGadget {
     font-size: 15px;
 }


### PR DESCRIPTION
A previous change removed the action button for everyone, even for admins. This commit will revert this until we find a better fix for the problem described in 4teamwork/bve.geko#30.
