### PR TITLE
Remove ticket identifier from ticket title.

### DIFF
--- a/izug/ticketbox/browser/tabbed/base.py
+++ b/izug/ticketbox/browser/tabbed/base.py
@@ -32,7 +32,7 @@ class BaseTicketListingTab(CatalogListingView):
                  },
 
                 {'column': 'Title',
-                 'column_title': _(u"Description"),
+                 'column_title': _(u"Title"),
                  'sort_index': 'sortable_title',
                  'transform': helper.linked_without_icon,
                  },

--- a/izug/ticketbox/content/ticket.py
+++ b/izug/ticketbox/content/ticket.py
@@ -246,8 +246,6 @@ TicketSchema['description'] = atapi.TextField(
                 default=u"Description"),
         rows=7))
 
-TicketSchema['title'].accessor = 'getTitle'
-
 schemata.finalizeATCTSchema(TicketSchema, moveDiscussion=False)
 
 
@@ -264,12 +262,6 @@ class Ticket(base.ATCTFolder):
     security = ClassSecurityInfo()
     meta_type = "Ticket"
     schema = TicketSchema
-
-    def Title(self):
-        if getattr(self, 'in_templates', None):
-            return self.getTitle()
-
-        return ' '.join((self.ticketIdentifier(), self.getTitle()))
 
     def ticketIdentifier(self):
         ticketbox = aq_parent(aq_inner(self))

--- a/izug/ticketbox/locales/de/LC_MESSAGES/izug.ticketbox.po
+++ b/izug/ticketbox/locales/de/LC_MESSAGES/izug.ticketbox.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-01-08 08:42+0000\n"
+"POT-Creation-Date: 2015-01-08 16:08+0000\n"
 "PO-Revision-Date: 2012-03-01 17:44+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -38,10 +38,6 @@ msgstr "Status"
 msgid "Delete"
 msgstr "Löschen"
 
-#: ./izug/ticketbox/browser/tabbed/base.py:35
-msgid "Description"
-msgstr "Beschreibung"
-
 #: ./izug/ticketbox/browser/tabbed/base.py:52
 msgid "DueDate"
 msgstr "Fälligkeit des Auftrages"
@@ -71,8 +67,8 @@ msgstr "Im Auftrag von"
 msgid "ModificationDate"
 msgstr "Änderungsdatum"
 
-#: ./izug/ticketbox/browser/helper.py:133
-#: ./izug/ticketbox/content/ticket.py:338
+#: ./izug/ticketbox/browser/helper.py:135
+#: ./izug/ticketbox/content/ticket.py:335
 msgid "No Issuer"
 msgstr "Kein Auftraggeber"
 
@@ -204,6 +200,7 @@ msgstr "Auftragskontrolle"
 msgid "Ticketnr"
 msgstr "Auftragsnr"
 
+#: ./izug/ticketbox/browser/tabbed/base.py:35
 #: ./izug/ticketbox/browser/tabbed/tabs.py:153
 #: ./izug/ticketbox/browser/tabbed/ticketboxes.py:56
 msgid "Title"
@@ -843,7 +840,7 @@ msgstr "Antwort bearbeiten"
 msgid "title_error_no_response"
 msgstr "Fehler: Keine Antwort zum bearbeiten gefunden."
 
-#: ./izug/ticketbox/browser/helper.py:123
+#: ./izug/ticketbox/browser/helper.py:124
 msgid "unassigned"
 msgstr "Nicht zugewiesen"
 

--- a/izug/ticketbox/locales/izug.ticketbox.pot
+++ b/izug/ticketbox/locales/izug.ticketbox.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-01-08 08:42+0000\n"
+"POT-Creation-Date: 2015-01-08 16:08+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -41,10 +41,6 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: ./izug/ticketbox/browser/tabbed/base.py:35
-msgid "Description"
-msgstr ""
-
 #: ./izug/ticketbox/browser/tabbed/base.py:52
 msgid "DueDate"
 msgstr ""
@@ -74,8 +70,8 @@ msgstr ""
 msgid "ModificationDate"
 msgstr ""
 
-#: ./izug/ticketbox/browser/helper.py:133
-#: ./izug/ticketbox/content/ticket.py:338
+#: ./izug/ticketbox/browser/helper.py:135
+#: ./izug/ticketbox/content/ticket.py:335
 msgid "No Issuer"
 msgstr ""
 
@@ -207,6 +203,7 @@ msgstr ""
 msgid "Ticketnr"
 msgstr ""
 
+#: ./izug/ticketbox/browser/tabbed/base.py:35
 #: ./izug/ticketbox/browser/tabbed/tabs.py:153
 #: ./izug/ticketbox/browser/tabbed/ticketboxes.py:56
 msgid "Title"
@@ -842,7 +839,7 @@ msgstr ""
 msgid "title_error_no_response"
 msgstr ""
 
-#: ./izug/ticketbox/browser/helper.py:123
+#: ./izug/ticketbox/browser/helper.py:124
 msgid "unassigned"
 msgstr ""
 

--- a/izug/ticketbox/upgrades/20150108171809_reindex_tickets_titles/upgrade.py
+++ b/izug/ticketbox/upgrades/20150108171809_reindex_tickets_titles/upgrade.py
@@ -1,0 +1,12 @@
+from ftw.upgrade import UpgradeStep
+
+
+class ReindexTicketsTitles(UpgradeStep):
+    """Reindex the titles of the tickets.
+    """
+
+    def __call__(self):
+        self.catalog_reindex_objects(
+            query={'object_provides': 'izug.ticketbox.interfaces.ITicket'},
+            idxs=['Title', 'sortable_title']
+        )


### PR DESCRIPTION
Since there will be exactly one ticket box it is no longer necessary to prepend the ticket identifier to the ticket's title.