### PR TITLE
use ftw.calendarwidget for responses

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.7.1 (unreleased)
 ------------------
 
+- Use ftw.calendarwidget on responseform.
+  [tschanzt]
+
 - Hide unused files in Ticketview.
   [tschanzt]
 

--- a/izug/ticketbox/browser/response.pt
+++ b/izug/ticketbox/browser/response.pt
@@ -360,11 +360,12 @@
                                 Set the new answer date for this issue
                             </div>
 
-                            <tal:vars define="uniqueItemIndex python: dict(next=0);
+                            <tal:vars define="plone_view context/@@plone;
+                                              uniqueItemIndex python: dict(next=0);
                                               formname string:response-add-form;
                                               inputname string:answerdate;
                                               inputvalue python: context.getAnswerDate()">
-                                <metal:box use-macro="here/calendar_macros/macros/calendarDatePickerBox">
+                                <metal:box use-macro="here/picker/macros/ftw_calendarDatePickerBox">
                                     a calendar, hopefully
                                 </metal:box>
                             </tal:vars>

--- a/izug/ticketbox/profiles/default/metadata.xml
+++ b/izug/ticketbox/profiles/default/metadata.xml
@@ -3,6 +3,7 @@
     <dependencies>
         <dependency>profile-Products.DataGridField:default</dependency>
         <dependency>profile-ftw.tabbedview:default</dependency>
+        <dependency>profile-ftw.calendarwidget:default</dependency>
     </dependencies>
 
 </metadata>

--- a/izug/ticketbox/testing.py
+++ b/izug/ticketbox/testing.py
@@ -33,6 +33,10 @@ class TicketBoxLayer(PloneSandboxLayer):
         xmlconfig.file('configure.zcml', ftw.notification.email,
                        context=configurationContext)
 
+        import ftw.calendarwidget
+        xmlconfig.file('configure.zcml', ftw.calendarwidget,
+                       context=configurationContext)
+
         import izug.ticketbox
         xmlconfig.file('configure.zcml', izug.ticketbox,
                        context=configurationContext)
@@ -47,6 +51,7 @@ class TicketBoxLayer(PloneSandboxLayer):
 
         z2.installProduct(app, 'ftw.notification.base')
         z2.installProduct(app, 'ftw.notification.email')
+        z2.installProduct(app, 'ftw.calendarwidget')
         z2.installProduct(app, 'izug.ticketbox')
         z2.installProduct(app, 'collective.MockMailHost')
         z2.installProduct(app, 'ftw.zipexport')

--- a/izug/ticketbox/upgrades/20150826100459_install_ftw_calendar_widget/upgrade.py
+++ b/izug/ticketbox/upgrades/20150826100459_install_ftw_calendar_widget/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class InstallFtwCalendarWidget(UpgradeStep):
+    """Install ftw calendar widget.
+    """
+
+    def __call__(self):
+        self.setup_install_profile('profile-ftw.calendarwidget:default')

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
         'Products.statusmessages',
         'ZODB3',
         'Zope2',
+        'ftw.calendarwidget',
         'ftw.notification.base',
         'ftw.notification.email',
         'ftw.tabbedview',


### PR DESCRIPTION
@jone We now use the ftw.calendarwidget for the response form.
<img width="725" alt="screen shot 2015-08-13 at 16 08 12" src="https://cloud.githubusercontent.com/assets/358342/9251998/718e01b4-41d6-11e5-88dc-94461f9a46fd.png">
