### PR TITLE
Fix ticket attachment type icon.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 4.7.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix ticket attachment type icon.
+  [jone]
 
 
 4.7.1 (2015-09-02)

--- a/izug/ticketbox/profiles/default/types/TicketAttachment.xml
+++ b/izug/ticketbox/profiles/default/types/TicketAttachment.xml
@@ -4,8 +4,7 @@
    i18n:domain="plone" xmlns:i18n="http://xml.zope.org/namespaces/i18n">
  <property name="title" i18n:translate="">TicketAttachment</property>
  <property name="description" i18n:translate="">A type for files.</property>
- <property
-    name="content_icon">icon_funktion_download.gif</property>
+ <property name="content_icon">++resource++izug.ticketbox.icons/icon_funktion_download.gif</property>
  <property name="content_meta_type">File</property>
  <property name="product">izug.ticketbox</property>
  <property name="factory">addTicketAttachment</property>

--- a/izug/ticketbox/upgrades/20151019114319_fix_ticket_attachment_icon_path/types/TicketAttachment.xml
+++ b/izug/ticketbox/upgrades/20151019114319_fix_ticket_attachment_icon_path/types/TicketAttachment.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<object name="TicketAttachment">
+    <property name="content_icon">++resource++izug.ticketbox.icons/icon_funktion_download.gif</property>
+</object>

--- a/izug/ticketbox/upgrades/20151019114319_fix_ticket_attachment_icon_path/upgrade.py
+++ b/izug/ticketbox/upgrades/20151019114319_fix_ticket_attachment_icon_path/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class FixTicketAttachmentIconPath(UpgradeStep):
+    """Fix ticket attachment icon path.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
Fixes #74 

The icons were moved from a skins folder to a resource directory.
The paths were updated for the other types, but the TicketAttachment type was not updated.

This change updates the icon path for the TicketAttachment content portal type too.