### PR TITLE
Add upgrade step which fixes the type icons.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.7.2 (unreleased)
 ------------------
 
+- Add upgrade step for the icons of the ticket and ticket box types (the icons
+  have been moved to a resources directory).
+  [mbaechtold]
+
 - Fix ticket attachment type icon.
   [jone]
 

--- a/izug/ticketbox/upgrades/20151023094852_fix_icons_for_ticket_and_ticket_box/types/Ticket.xml
+++ b/izug/ticketbox/upgrades/20151023094852_fix_icons_for_ticket_and_ticket_box/types/Ticket.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<object name="Ticket">
+    <property name="content_icon">++resource++izug.ticketbox.icons/icon_objekt_aufgabe.gif</property>
+</object>

--- a/izug/ticketbox/upgrades/20151023094852_fix_icons_for_ticket_and_ticket_box/types/Ticket_Box.xml
+++ b/izug/ticketbox/upgrades/20151023094852_fix_icons_for_ticket_and_ticket_box/types/Ticket_Box.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<object name="Ticket Box">
+    <property name="content_icon">++resource++izug.ticketbox.icons/icon_objekt_auftragsbox.gif</property>
+</object>

--- a/izug/ticketbox/upgrades/20151023094852_fix_icons_for_ticket_and_ticket_box/upgrade.py
+++ b/izug/ticketbox/upgrades/20151023094852_fix_icons_for_ticket_and_ticket_box/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class FixIconsForTicketAndTicketBox(UpgradeStep):
+    """Fix icons for ticket and ticket box.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
The icon of the ticket attachment type has been changed recently (see https://github.com/4teamwork/izug.ticketbox/pull/75), including an upgrade step for existing installations.

But the icons of the ticket and ticket box types have been changed earlier (in the default profile) without providing an upgrade step.

This has been inspired by #75.