### PR TITLE
Fix display failure when adding a comment in a notificationform.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.7.2 (unreleased)
 ------------------
 
+- Fix display failure when adding a comment in a notificationform.
+  [elioschmutz]
+
 - Add upgrade step for the icons of the ticket and ticket box types (the icons
   have been moved to a resources directory).
   [mbaechtold]

--- a/izug/ticketbox/browser/notification/ticket.pt
+++ b/izug/ticketbox/browser/notification/ticket.pt
@@ -6,7 +6,7 @@
 	A new Answer has been Added by <span i18n:name="creator" tal:content="view/creator" /> in the Ticketbox <span i18n:name="tracker_name" tal:content="infos/tracker_title" /> (<span i18n:name="tracker_url" tal:content="infos/tracker_url" />)
 </p>
 <span tal:condition="view/comment" i18n:translate="" i18n:domain="ftw.notification.email">comment</span>
-<p tal:condition="view/comment" tal:content="view/comment"></p>
+<p tal:condition="view/comment" tal:content="structure view/comment"></p>
 <br />
 <span tal:condition="python: infos['response']==False" i18n:translate="">Issue Information</span>
 <span tal:condition="python: infos['response']==True" i18n:translate="">Response Information</span>

--- a/izug/ticketbox/tests/test_notification.py
+++ b/izug/ticketbox/tests/test_notification.py
@@ -44,9 +44,26 @@ class TestResponseNotification(unittest.TestCase):
         list_to = self.browser.getControl(name="to_list:list")
         list_to.controls[0].selected = True
         self.browser.getControl(name='form.button.Send').click()
+
         self.assertIn(
             'A new Answer has been Added by <span>fullnamea</span> in the '
             'Ticketbox',
+            self.portal.MailHost.messages[0])
+
+    def test_notifiaction_comment(self):
+        self.browser.addHeader('Authorization', 'Basic %s:%s' % (
+                "usera", "usera",))
+        self.browser.open(self.ticket1.absolute_url())
+        self.browser.getControl("High").selected = True
+        self.browser.getControl("Send notification").selected = True
+        self.browser.getControl(name="submit").click()
+        list_to = self.browser.getControl(name="to_list:list")
+        list_to.controls[0].selected = True
+        self.browser.getControl(name="comment").value = "James\r\nB\xc3\xa4nd"
+        self.browser.getControl(name='form.button.Send').click()
+
+        self.assertIn(
+            'James\nB=C3=A4nd',
             self.portal.MailHost.messages[0])
 
     def test_fullname_on_ticket_notification(self):


### PR DESCRIPTION
Fix a display failure when using comments in the notificationform.

form:
-------
![bildschirmfoto 2015-12-11 um 12 23 40](https://cloud.githubusercontent.com/assets/557005/11742730/7c1cec96-a002-11e5-81fb-c22035dd8be9.png)

before:
----------
![bildschirmfoto 2015-12-11 um 12 23 28](https://cloud.githubusercontent.com/assets/557005/11742735/81042634-a002-11e5-8854-d1dade74bbc8.png)

after:
-------
![bildschirmfoto 2015-12-11 um 12 23 19](https://cloud.githubusercontent.com/assets/557005/11742747/8bfdfc54-a002-11e5-8727-467bc289cbbe.png)
 