### PR TITLE
Fix answerdate in ticket response

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,10 @@ Changelog
 4.7.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix answerdate in ticket response
+  It was not possible to set a answerdate in the response of a ticket.
+  Neither through manual input nor calendar widget.
+  [elioschmutz]
 
 
 4.7.2 (2015-12-22)

--- a/izug/ticketbox/browser/response.py
+++ b/izug/ticketbox/browser/response.py
@@ -519,16 +519,23 @@ class Create(Base):
                                     before, after)
             issue_has_changed = True
 
-        #Answerdate
-        answerdate_after = form.get('answerdate')
-        if answerdate_after:
-            answerdate_after = DateTime(answerdate_after).strftime(
-                '%d.%m.%Y %H:%M')
+        # Answerdate
         answerdate_before = context.getAnswerDate()
         if answerdate_before:
             answerdate_before = answerdate_before.strftime('%d.%m.%Y %H:%M')
         else:
             answerdate_before = ''
+
+        answerdate_after = answerdate_before
+        year = int(form.get('answerdate_year', 0))
+        month = int(form.get('answerdate_month', 0))
+        day = int(form.get('answerdate_day', 0))
+
+        if year and month and day:
+            hour = int(form.get('answerdate_hour', 0))
+            minute = int(form.get('answerdate_minute', 0))
+            answerdate_after = DateTime(
+                year, month, day, hour, minute).strftime('%d.%m.%Y %H:%M')
 
         if answerdate_before != answerdate_after:
             context.setAnswerDate(answerdate_after)

--- a/izug/ticketbox/tests/test_response.py
+++ b/izug/ticketbox/tests/test_response.py
@@ -1,13 +1,18 @@
+from DateTime import DateTime
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import statusmessages
 from izug.ticketbox.adapters import Response
 from izug.ticketbox.interfaces import IResponseContainer
-from izug.ticketbox.testing import TICKETBOX_INTEGRATION_TESTING
+from izug.ticketbox.testing import TICKETBOX_FUNCTIONAL_TESTING
 from izug.ticketbox.tests import helpers
 from unittest2 import TestCase
 
 
 class TestResponse(TestCase):
 
-    layer = TICKETBOX_INTEGRATION_TESTING
+    layer = TICKETBOX_FUNCTIONAL_TESTING
 
     def setUp(self):
         super(TestResponse, self).setUp()
@@ -48,3 +53,129 @@ class TestResponse(TestCase):
         self.assertEquals(response1 in self.container1, False)
         self.assertEquals(response2 in self.container1, False)
         self.assertEquals(response3 in self.container2, True)
+
+    @browsing
+    def test_update_anserdate_if_given(self, browser):
+        ticketbox = create(Builder('ticket box'))
+        ticket = create(Builder('ticket')
+                        .having(answerDate=DateTime(2015, 12, 31))
+                        .within(ticketbox))
+
+        browser.login().visit(ticket)
+
+        browser.fill({
+            'answerdate_year': '2021',
+            'answerdate_month': 'April',
+            'answerdate_day': '12',
+            'answerdate_hour': '10',
+            'answerdate_minute': '05'}).submit()
+
+        self.assertEqual(
+            1, len(browser.css('.response-reply')),
+            "There should be one response visible")
+
+        self.assertEqual(
+            ['31.12.2015 00:00', '12.04.2021 10:05'],
+            browser.css('.response-reply .issueChange').text,
+            "The answerdate before and the answerdatedate after should "
+            "be visible in the answer")
+
+    @browsing
+    def test_do_not_update_anserdate_if_no_new_date_is_given(self, browser):
+        ticketbox = create(Builder('ticket box'))
+        ticket = create(Builder('ticket')
+                        .having(answerDate=DateTime(2015, 12, 31, 9, 50))
+                        .within(ticketbox))
+
+        browser.login().visit(ticket)
+
+        browser.fill({
+            'answerdate_year': '2015',
+            'answerdate_month': 'December',
+            'answerdate_day': '31',
+            'answerdate_hour': '09',
+            'answerdate_minute': '50'}).submit()
+
+        self.assertEqual(
+            ['No response text added and no issue changes made.'],
+            statusmessages.error_messages())
+
+    @browsing
+    def test_do_not_update_anserdate_if_no_year_is_given(self, browser):
+        ticketbox = create(Builder('ticket box'))
+        ticket = create(Builder('ticket')
+                        .having(answerDate=DateTime(2015, 12, 31))
+                        .within(ticketbox))
+
+        browser.login().visit(ticket)
+
+        browser.fill({
+            'answerdate_year': '--',
+            'answerdate_month': 'April',
+            'answerdate_day': '04',
+            'answerdate_hour': '09',
+            'answerdate_minute': '00'}).submit()
+
+        self.assertEqual(
+            ['No response text added and no issue changes made.'],
+            statusmessages.error_messages())
+
+    @browsing
+    def test_do_not_update_anserdate_if_no_month_is_given(self, browser):
+        ticketbox = create(Builder('ticket box'))
+        ticket = create(Builder('ticket')
+                        .having(answerDate=DateTime(2015, 12, 31))
+                        .within(ticketbox))
+
+        browser.login().visit(ticket)
+
+        browser.fill({
+            'answerdate_year': '2021',
+            'answerdate_month': '--',
+            'answerdate_day': '04',
+            'answerdate_hour': '09',
+            'answerdate_minute': '00'}).submit()
+
+        self.assertEqual(
+            ['No response text added and no issue changes made.'],
+            statusmessages.error_messages())
+
+    @browsing
+    def test_do_not_update_anserdate_if_no_day_is_given(self, browser):
+        ticketbox = create(Builder('ticket box'))
+        ticket = create(Builder('ticket')
+                        .having(answerDate=DateTime(2015, 12, 31))
+                        .within(ticketbox))
+
+        browser.login().visit(ticket)
+
+        browser.fill({
+            'answerdate_year': '2021',
+            'answerdate_month': 'April',
+            'answerdate_day': '--',
+            'answerdate_hour': '09',
+            'answerdate_minute': '00'}).submit()
+
+        self.assertEqual(
+            ['No response text added and no issue changes made.'],
+            statusmessages.error_messages())
+
+    @browsing
+    def test_update_anserdate_if_no_hour_or_minute_is_given(self, browser):
+        ticketbox = create(Builder('ticket box'))
+        ticket = create(Builder('ticket')
+                        .having(answerDate=DateTime(2015, 12, 31))
+                        .within(ticketbox))
+
+        browser.login().visit(ticket)
+
+        browser.fill({
+            'answerdate_year': '2021',
+            'answerdate_month': 'April',
+            'answerdate_day': '12',
+            'answerdate_hour': '--',
+            'answerdate_minute': '--'}).submit()
+
+        self.assertEqual(
+            1, len(browser.css('.response-reply')),
+            "There should be one response visible")


### PR DESCRIPTION
It was not possible to set an answerdate in the response of a ticket.
Neither through manual input nor calendar widget.

This issue will be fixed through this PR.

Before:
----------

![test](https://cloud.githubusercontent.com/assets/557005/12202130/857e717e-b628-11e5-9595-09a14343d327.gif)

After:
-------

![test](https://cloud.githubusercontent.com/assets/557005/12202172/bdf6cbc8-b628-11e5-8932-e6ec84c8b9a1.gif)
