### PR TITLE
Fix the global ticketbox tabs.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 4.9.2 (unreleased)
 ------------------
 
+- Fix tabbed view. [mbaechtold]
+
 - Drop support for Plone 4.2. [mbaechtold]
 
 

--- a/izug/ticketbox/browser/tabbed/ticketboxes.py
+++ b/izug/ticketbox/browser/tabbed/ticketboxes.py
@@ -28,16 +28,16 @@ class TicketboxesTabbedView(TabbedView):
 
     def get_tabs(self):
         return (
-            {'id': _('global-my_tickets'),
+            {'id': 'global-my_tickets',
              'class': ''},
 
-            {'id': _('global-my_issued_tickets'),
+            {'id': 'global-my_issued_tickets',
              'class': ''},
 
-            {'id': _('global-all_tickets'),
+            {'id': 'global-all_tickets',
              'class': ''},
 
-            {'id': _('global-ticketboxes'),
+            {'id': 'global-ticketboxes',
              'class': ''},
         )
 

--- a/izug/ticketbox/locales/de/LC_MESSAGES/ftw.tabbedview.po
+++ b/izug/ticketbox/locales/de/LC_MESSAGES/ftw.tabbedview.po
@@ -17,6 +17,18 @@ msgstr "Alle Aufträge"
 msgid "attachments"
 msgstr "Anhänge"
 
+msgid "global-all_tickets"
+msgstr "Alle Aufträge"
+
+msgid "global-my_issued_tickets"
+msgstr "Erteilte Aufträge"
+
+msgid "global-my_tickets"
+msgstr "Meine Aufträge"
+
+msgid "global-ticketboxes"
+msgstr "Auftragsboxen"
+
 msgid "info_view"
 msgstr "Info"
 

--- a/izug/ticketbox/locales/en/LC_MESSAGES/ftw.tabbedview.po
+++ b/izug/ticketbox/locales/en/LC_MESSAGES/ftw.tabbedview.po
@@ -17,6 +17,18 @@ msgstr "All tickets"
 msgid "attachments"
 msgstr "Attachments"
 
+msgid "global-all_tickets"
+msgstr "All tickets"
+
+msgid "global-my_issued_tickets"
+msgstr "Issued tickets"
+
+msgid "global-my_tickets"
+msgstr "My tickets"
+
+msgid "global-ticketboxes"
+msgstr "Ticketboxes"
+
 msgid "info_view"
 msgstr "Info"
 
@@ -28,3 +40,4 @@ msgstr "My tickets"
 
 msgid "overview"
 msgstr "Overview"
+

--- a/izug/ticketbox/locales/fr/LC_MESSAGES/ftw.tabbedview.po
+++ b/izug/ticketbox/locales/fr/LC_MESSAGES/ftw.tabbedview.po
@@ -17,6 +17,18 @@ msgstr "Tous les tâches"
 msgid "attachments"
 msgstr "Pièces jointes"
 
+msgid "global-all_tickets"
+msgstr "Tous les tâches"
+
+msgid "global-my_issued_tickets"
+msgstr "Tâches allouées"
+
+msgid "global-my_tickets"
+msgstr "Mes tâches"
+
+msgid "global-ticketboxes"
+msgstr "Ticketboxes"
+
 msgid "info_view"
 msgstr "Info"
 

--- a/izug/ticketbox/locales/ftw.tabbedview.pot
+++ b/izug/ticketbox/locales/ftw.tabbedview.pot
@@ -35,3 +35,15 @@ msgstr ""
 
 msgid "issued_tickets"
 msgstr ""
+
+msgid "global-my_tickets"
+msgstr ""
+
+msgid "global-my_issued_tickets"
+msgstr ""
+
+msgid "global-all_tickets"
+msgstr ""
+
+msgid "global-ticketboxes"
+msgstr ""


### PR DESCRIPTION
The name of the tab is used to build the name of the view to be loaded in the tab. But views named like `tabbedview_view-Meine Aufträge` do not exist. We can fix this by no longer using gettext objects in the tab configuration. If we do so, the names of the tabs are still internationalized automagically.

## Before

<img width="1679" alt="image" src="https://user-images.githubusercontent.com/28220/53864072-e5fdf100-3feb-11e9-9d68-fe6372e8296c.png">

## After

<img width="1679" alt="image" src="https://user-images.githubusercontent.com/28220/53864320-7805f980-3fec-11e9-8dd0-cc45c960c248.png">
